### PR TITLE
ViewClaimsDashboardUseCase implemented

### DIFF
--- a/flex/src/main/java/consonants/flex/data_access/mongo_data_access/ClaimRepository.java
+++ b/flex/src/main/java/consonants/flex/data_access/mongo_data_access/ClaimRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 @Repository
 public interface ClaimRepository extends MongoRepository<Claim, ObjectId> {
-    Optional<Claim> findClaimByClaimId(int claimId);
+    Claim findClaimByClaimId(int claimId);
 }

--- a/flex/src/main/java/consonants/flex/data_access/mongo_data_access/ClientRepository.java
+++ b/flex/src/main/java/consonants/flex/data_access/mongo_data_access/ClientRepository.java
@@ -6,6 +6,8 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/flex/src/main/java/consonants/flex/data_access/mongo_data_access/MongoDataAccessObject.java
+++ b/flex/src/main/java/consonants/flex/data_access/mongo_data_access/MongoDataAccessObject.java
@@ -149,8 +149,8 @@ public class MongoDataAccessObject implements ViewAllClaimsDataAccessInterface, 
      */
     public List<Integer> getClaimFormIds(int claimId) {
         if (claimExistsById(claimId)) {
-            Optional<Claim> claim = claimRepository.findClaimByClaimId(claimId);
-            return claim.get().getForms();
+            Claim claim = claimRepository.findClaimByClaimId(claimId);
+            return claim.getForms();
         }
         return new ArrayList<>();
     }

--- a/flex/src/main/java/consonants/flex/entity/Client.java
+++ b/flex/src/main/java/consonants/flex/entity/Client.java
@@ -33,7 +33,9 @@ public class Client {
     public int getClientId(){
         return this.clientId;
     }
-    public List<Integer> getClaims(){return claimsList;}
+
+
+    public List<Integer> getClaims() {return claimsList;}
 
 
     /**

--- a/flex/src/main/java/consonants/flex/interface_adapter/view_claims_dashboard/ViewClaimsDashboardController.java
+++ b/flex/src/main/java/consonants/flex/interface_adapter/view_claims_dashboard/ViewClaimsDashboardController.java
@@ -1,0 +1,24 @@
+package consonants.flex.interface_adapter.view_claims_dashboard;
+
+import consonants.flex.entity.Claim;
+import consonants.flex.use_case.view_claims_dashboard.ViewClaimsDashboardInputBoundary;
+import consonants.flex.use_case.view_claims_dashboard.ViewClaimsDashboardInputData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping("/{clientId}")
+public class ViewClaimsDashboardController {
+    @Autowired
+    private ViewClaimsDashboardInputBoundary viewClaimsDashboardInteractor;
+
+    @GetMapping("/claims")
+    public ResponseEntity<List<Claim>> viewClaims(@PathVariable int clientId) {
+        ViewClaimsDashboardInputData inputData = new ViewClaimsDashboardInputData(clientId);
+        return viewClaimsDashboardInteractor.execute(inputData);
+    }
+}

--- a/flex/src/main/java/consonants/flex/interface_adapter/view_claims_dashboard/ViewClaimsDashboardPresenter.java
+++ b/flex/src/main/java/consonants/flex/interface_adapter/view_claims_dashboard/ViewClaimsDashboardPresenter.java
@@ -1,0 +1,14 @@
+package consonants.flex.interface_adapter.view_claims_dashboard;
+
+import consonants.flex.entity.Claim;
+import consonants.flex.use_case.view_claims_dashboard.ViewClaimsDashboardOutputBoundary;
+import consonants.flex.use_case.view_claims_dashboard.ViewClaimsDashboardOutputData;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ViewClaimsDashboardPresenter implements ViewClaimsDashboardOutputBoundary {
+    @Override
+    public List<Claim> viewClaims(ViewClaimsDashboardOutputData outputData) {return outputData.getClaims();}
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardDataAccessInterface.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardDataAccessInterface.java
@@ -1,0 +1,22 @@
+package consonants.flex.use_case.view_claims_dashboard;
+
+import consonants.flex.entity.Claim;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ViewClaimsDashboardDataAccessInterface {
+
+    /**
+     * @param clientId the id of the Client.
+     * @return List of Integers corresponding to claimIds for Claims belonging to the Client ; Empty otherwise.
+     */
+    List<Integer> getClientClaimIds(int clientId);
+
+
+    /**
+     * @param claimIds The integers from the Client's claimList.
+     * @return List of Claim objects corresponding to claimIds for Claims belonging to the Client ; Empty otherwise.
+     */
+    List<Claim> getClientClaimsListAsClaims(List<Integer> claimIds);
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardInputBoundary.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardInputBoundary.java
@@ -1,0 +1,10 @@
+package consonants.flex.use_case.view_claims_dashboard;
+
+import consonants.flex.entity.Claim;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface ViewClaimsDashboardInputBoundary {
+    ResponseEntity<List<Claim>> execute(ViewClaimsDashboardInputData inputData);
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardInputData.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardInputData.java
@@ -1,0 +1,9 @@
+package consonants.flex.use_case.view_claims_dashboard;
+
+public class ViewClaimsDashboardInputData {
+    final private int clientId;
+
+    public ViewClaimsDashboardInputData(int clientId) {this.clientId = clientId;}
+
+    int getClientId() {return this.clientId;}
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardInteractor.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardInteractor.java
@@ -1,0 +1,38 @@
+package consonants.flex.use_case.view_claims_dashboard;
+
+import consonants.flex.entity.Claim;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+@RestController
+public class ViewClaimsDashboardInteractor implements ViewClaimsDashboardInputBoundary{
+    @Autowired
+    private final ViewClaimsDashboardDataAccessInterface claimDataAccessObject;
+
+    @Autowired
+    private final ViewClaimsDashboardOutputBoundary viewClaimsDashboardPresenter;
+
+    public ViewClaimsDashboardInteractor(ViewClaimsDashboardDataAccessInterface claimDataAccessObject, ViewClaimsDashboardOutputBoundary viewClaimsDashboardPresenter) {
+        this.claimDataAccessObject = claimDataAccessObject;
+        this.viewClaimsDashboardPresenter = viewClaimsDashboardPresenter;
+    }
+
+    /**
+     * Accesses DAO to first generate list of integers containing claimIds from Client object.
+     * Accesses DAO again to generate a list of claim objects after retrieving the claimsList from Client object.
+     * @param inputData is sent from the controller. An object that stores the clientId for the use case.
+     * @return Response that includes a List of Claim objects belonging to the Client. Returns empty list if client
+     * does not exist or if client has no claims. This controller should only be called after login (i.e. Client exists)
+     */
+    @Override
+    public ResponseEntity<List<Claim>> execute(ViewClaimsDashboardInputData inputData) {
+        int clientId = inputData.getClientId();
+        List<Integer> claimIds = claimDataAccessObject.getClientClaimIds(clientId);
+        List<Claim> claims = claimDataAccessObject.getClientClaimsListAsClaims(claimIds);
+        ViewClaimsDashboardOutputData outputData = new ViewClaimsDashboardOutputData(claims);
+        return new ResponseEntity<>(viewClaimsDashboardPresenter.viewClaims(outputData), HttpStatus.OK);
+    }
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardOutputBoundary.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardOutputBoundary.java
@@ -1,0 +1,9 @@
+package consonants.flex.use_case.view_claims_dashboard;
+
+import consonants.flex.entity.Claim;
+
+import java.util.List;
+
+public interface ViewClaimsDashboardOutputBoundary {
+    List<Claim> viewClaims(ViewClaimsDashboardOutputData outputData);
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardOutputData.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_claims_dashboard/ViewClaimsDashboardOutputData.java
@@ -1,0 +1,13 @@
+package consonants.flex.use_case.view_claims_dashboard;
+
+import consonants.flex.entity.Claim;
+
+import java.util.List;
+
+public class ViewClaimsDashboardOutputData {
+    private final List<Claim> claims;
+
+    public ViewClaimsDashboardOutputData(List<Claim> claims) {this.claims = claims;}
+
+    public List<Claim> getClaims() {return this.claims;}
+}


### PR DESCRIPTION
ViewClaimsDashBoard Use Case

## Motivation and Context

Creates one of the use cases in our user journey. This brings forth a list of claims belonging to a Client using the {clientId} to do so. This will be the core functionality required for the Claims Dashboard page that each Client has. Returns an empty list if client does not exist or if client has not yet created a claim. Since the page should only be access after a client exists, the empty list will serve as indication that there are no claims yet created by this client.

## Your Changes

Implemented all classes and methods as required by CA for the ViewClaimsDashboard Use Case. Namely have added to the interface_adaptors and use_case packages. Additionally, have added a couple of methods into the DAO to provide functionality necessary for the use case. See changes in code. 

**Type of change** (select all that apply):

- [x] New feature (non-breaking change which adds functionality)

## Notes for Reviewer

To test, run FlexApplication > go to http://localhost:8080/1234/claims. This should return two claims belonging to the Client with clientId 1234. The two claimIds should be 1010, and 1012. Then try http://localhost:8080/207/claims (or any other client not in our database). Should return an empty list.

## Checklist

- [x] I have performed a self-review of my own code.
