### PR TITLE
ViewFormsDashboardUseCase implemented

### DIFF
--- a/flex/src/main/java/consonants/flex/data_access/mongo_data_access/FormRepository.java
+++ b/flex/src/main/java/consonants/flex/data_access/mongo_data_access/FormRepository.java
@@ -1,6 +1,7 @@
 package consonants.flex.data_access.mongo_data_access;
 
 import consonants.flex.entity.Form;
+import consonants.flex.entity.LCInfoRequest;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface FormRepository extends MongoRepository<Form, ObjectId> {
-    Optional<Form> findFormByFormId(int formId);
+    Form findFormByFormId(int formId);
+    LCInfoRequest findLCFormByFormId(int formId);
 }

--- a/flex/src/main/java/consonants/flex/entity/LCInfoRequest.java
+++ b/flex/src/main/java/consonants/flex/entity/LCInfoRequest.java
@@ -1,7 +1,16 @@
 package consonants.flex.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import java.util.ArrayList;
 
+@Document(collection = "forms")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class LCInfoRequest extends Form{
 
     // **** claims checklist

--- a/flex/src/main/java/consonants/flex/interface_adapter/view_forms_dashboard/ViewFormsDashboardController.java
+++ b/flex/src/main/java/consonants/flex/interface_adapter/view_forms_dashboard/ViewFormsDashboardController.java
@@ -1,0 +1,24 @@
+package consonants.flex.interface_adapter.view_forms_dashboard;
+
+import consonants.flex.entity.Form;
+import consonants.flex.use_case.view_forms_dashboard.ViewFormsDashboardInputBoundary;
+import consonants.flex.use_case.view_forms_dashboard.ViewFormsDashboardInputData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping("/{clientId}/{claimId}")
+public class ViewFormsDashboardController {
+    @Autowired
+    private ViewFormsDashboardInputBoundary viewFormsDashboardInteractor;
+
+    @GetMapping("/forms")
+    public ResponseEntity<List<Form>> viewClaims(@PathVariable int clientId, @PathVariable int claimId) {
+        ViewFormsDashboardInputData inputData = new ViewFormsDashboardInputData(clientId, claimId);
+        return viewFormsDashboardInteractor.execute(inputData);
+    }
+}

--- a/flex/src/main/java/consonants/flex/interface_adapter/view_forms_dashboard/ViewFormsDashboardPresenter.java
+++ b/flex/src/main/java/consonants/flex/interface_adapter/view_forms_dashboard/ViewFormsDashboardPresenter.java
@@ -1,0 +1,14 @@
+package consonants.flex.interface_adapter.view_forms_dashboard;
+
+import consonants.flex.entity.Form;
+import consonants.flex.use_case.view_forms_dashboard.ViewFormsDashboardOutputBoundary;
+import consonants.flex.use_case.view_forms_dashboard.ViewFormsDashboardOutputData;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ViewFormsDashboardPresenter implements ViewFormsDashboardOutputBoundary {
+    @Override
+    public List<Form> viewForms(ViewFormsDashboardOutputData outputData) {return outputData.getForms();}
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardDataAccessInterface.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardDataAccessInterface.java
@@ -1,0 +1,10 @@
+package consonants.flex.use_case.view_forms_dashboard;
+
+import consonants.flex.entity.Form;
+
+import java.util.List;
+
+public interface ViewFormsDashboardDataAccessInterface {
+
+    List<Form> getFormsListAsForms(int clientId, int claimId);
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardInputBoundary.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardInputBoundary.java
@@ -1,0 +1,10 @@
+package consonants.flex.use_case.view_forms_dashboard;
+
+import consonants.flex.entity.Form;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface ViewFormsDashboardInputBoundary {
+    ResponseEntity<List<Form>> execute(ViewFormsDashboardInputData inputData);
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardInputData.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardInputData.java
@@ -1,0 +1,14 @@
+package consonants.flex.use_case.view_forms_dashboard;
+
+public class ViewFormsDashboardInputData {
+    final private int clientId;
+    final private int claimId;
+
+    public ViewFormsDashboardInputData(int clientId, int claimId) {
+        this.clientId = clientId;
+        this.claimId = claimId;
+    }
+
+    int getClientId() {return this.clientId;}
+    int getClaimId() {return this.claimId;}
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardInteractor.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardInteractor.java
@@ -1,0 +1,32 @@
+package consonants.flex.use_case.view_forms_dashboard;
+
+import consonants.flex.entity.Form;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class ViewFormsDashboardInteractor implements ViewFormsDashboardInputBoundary {
+    @Autowired
+    private final ViewFormsDashboardDataAccessInterface formDataAccessObject;
+
+    @Autowired
+    private final ViewFormsDashboardOutputBoundary viewFormsDashboardPresenter;
+
+    public ViewFormsDashboardInteractor(ViewFormsDashboardDataAccessInterface formDataAccessObject, ViewFormsDashboardOutputBoundary viewFormsDashboardPresenter) {
+        this.formDataAccessObject = formDataAccessObject;
+        this.viewFormsDashboardPresenter = viewFormsDashboardPresenter;
+    }
+
+    @Override
+    public ResponseEntity<List<Form>> execute(ViewFormsDashboardInputData inputData) {
+        int clientId = inputData.getClientId();
+        int claimId = inputData.getClaimId();
+        List<Form> forms = formDataAccessObject.getFormsListAsForms(clientId, claimId);
+        ViewFormsDashboardOutputData outputData = new ViewFormsDashboardOutputData(forms);
+        return new ResponseEntity<>(viewFormsDashboardPresenter.viewForms(outputData), HttpStatus.OK);
+    }
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardOutputBoundary.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardOutputBoundary.java
@@ -1,0 +1,9 @@
+package consonants.flex.use_case.view_forms_dashboard;
+
+import consonants.flex.entity.Form;
+
+import java.util.List;
+
+public interface ViewFormsDashboardOutputBoundary {
+    List<Form> viewForms(ViewFormsDashboardOutputData outputData);
+}

--- a/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardOutputData.java
+++ b/flex/src/main/java/consonants/flex/use_case/view_forms_dashboard/ViewFormsDashboardOutputData.java
@@ -1,0 +1,13 @@
+package consonants.flex.use_case.view_forms_dashboard;
+
+import consonants.flex.entity.Form;
+
+import java.util.List;
+
+public class ViewFormsDashboardOutputData {
+    private final List<Form> forms;
+
+    public ViewFormsDashboardOutputData(List<Form> forms) {this.forms = forms;}
+
+    public List<Form> getForms() {return this.forms;}
+}


### PR DESCRIPTION
ViewFormsDashboard Use Case
## Motivation and Context
Creates one of the use cases in our user journey. This brings forth a list of forms belonging to a specific Claim and uses both the {claimId} and {clientId} to confirm this. This will be the core functionality required for the Forms Dashboard page that each Claim has. Returns an empty list if client does not contain the specified claimId or if claimId does not exist. Since the page should only be accessed after a client and claim exists, the empty list will serve as indicates something has gone wrong.

## Your Changes
Implemented all classes and methods as required by CA for the ViewFormsDashboard Use Case. Namely have added to the interface_adaptors and use_case packages. Additionally, have added a couple of methods into the DAO to provide functionality necessary for the use case. See changes in code.

**Type of change** (select all that apply):

[x] New feature (non-breaking change which adds functionality)

## Notes for Reviewer

To test, run FlexApplication > go to http://localhost:8080/1234/1010/forms or http://localhost:8080/5678/1002/forms. 

The format of the URL is localhost:8080/{clientId}/{claimId}/forms

This should return the forms involved in claim #1010 (formId should be 12) and #1002 (formId should be 2) respectively. Also, clientIds that do not exist or claimIds that do not belong to the Client specified by clientId should return an empty list of forms. You can try this by entering a random clientID for claim 1010 or a random claimID for client 1234 and observe the response.


## Checklist

- [x] I have performed a self-review of my own code.
