### PR TITLE
Reformatted OCR date order

### DIFF
--- a/flex/src/main/java/consonants/flex/data_access/mongo_data_access/DocumentIntelligence.java
+++ b/flex/src/main/java/consonants/flex/data_access/mongo_data_access/DocumentIntelligence.java
@@ -72,22 +72,24 @@ public class DocumentIntelligence {
                     formFields.put("deceasedName", formFieldValue);
 
                 } else if (keyValuePair.getKey().getContent().equals("Date of birth (mo/day/yr)")) {
-                    String formFieldValue = keyValuePair.getValue().getContent();
-                    formFields.put("dateOfBirth", formFieldValue);
+                    String[] formFieldValue = keyValuePair.getValue().getContent().split("/");
+                    String rearrangedFormField = formFieldValue[2] + '-' + formFieldValue[0] + '-' + formFieldValue[1];
+                    formFields.put("dateOfBirth", rearrangedFormField);
 
                 } else if (keyValuePair.getKey().getContent().equals("Date of death (mo/day/yr)")) {
-                    String formFieldValue = keyValuePair.getValue().getContent();
-                    formFields.put("dateOfDeath", formFieldValue);
+                    String[] formFieldValue = keyValuePair.getValue().getContent().split("/");
+                    String rearrangedFormField = formFieldValue[2] + '-' + formFieldValue[0] + '-' + formFieldValue[1];
+                    formFields.put("dateOfDeath", rearrangedFormField);
 
                 } else if (keyValuePair.getKey().getContent().equals("Cause of death")) {
                     String formFieldValue = keyValuePair.getValue().getContent();
                     formFields.put("causeOfDeath", formFieldValue);
 
                 } else if (keyValuePair.getKey().getContent().equals("If yes, date admitted:")) {
-                    String formFieldValue = keyValuePair.getValue().getContent();
+                    String[] formFieldValue = keyValuePair.getValue().getContent().split("/");
+                    String rearrangedFormField = formFieldValue[2] + '-' + formFieldValue[0] + '-' + formFieldValue[1];
                     formFields.put("deceasedHospitalized", true);
-                    formFields.put("hospitalizationDate", formFieldValue);
-
+                    formFields.put("hospitalizationDate", rearrangedFormField);
                 } else if (keyValuePair.getKey().getContent().equals("Name of hospital")) {
                     String formFieldValue = keyValuePair.getValue().getContent();
                     formFields.put("hospitalName", formFieldValue);
@@ -133,8 +135,9 @@ public class DocumentIntelligence {
                     String formFieldValue = keyValuePair.getValue().getContent();
                     formFields.put("occupation", formFieldValue);
                 } else if (keyValuePair.getKey().getContent().equals("Date last worked (mo/day/yr)")) {
-                    String formFieldValue = keyValuePair.getValue().getContent();
-                    formFields.put("dateLastWorked", formFieldValue);
+                    String[] formFieldValue = keyValuePair.getValue().getContent().split("/");
+                    String rearrangedFormField = formFieldValue[2] + '-' + formFieldValue[0] + '-' + formFieldValue[1];
+                    formFields.put("dateLastWorked", rearrangedFormField);
                 } else if (keyValuePair.getKey().getContent().equals("Employer")) {
                     String formFieldValue = keyValuePair.getValue().getContent();
                     formFields.put("employer", formFieldValue);
@@ -160,8 +163,9 @@ public class DocumentIntelligence {
                     String formFieldValue = keyValuePair.getValue().getContent();
                     formFields.put("kinSignature", formFieldValue);
                 } else if (keyValuePair.getKey().getContent().equals("Date signed (mo/day/yr)")) {
-                    String formFieldValue = keyValuePair.getValue().getContent();
-                    formFields.put("dateSigned", formFieldValue);
+                    String[] formFieldValue = keyValuePair.getValue().getContent().split("/");
+                    String rearrangedFormField = formFieldValue[2] + '-' + formFieldValue[0] + '-' + formFieldValue[1];
+                    formFields.put("dateSigned", rearrangedFormField);
                 }
 
                 if (keyValuePair.getKey().getContent().equals("Normal retirement") && keyValuePair.getValue().getContent().equals(":selected:")) {
@@ -192,9 +196,9 @@ public class DocumentIntelligence {
 
         }
 
-    //     for (Map.Entry<String, Object> entry : formFields.entrySet()) {
-    //         System.out.println(entry.getKey() + ": " + entry.getValue());
-    // }
+         for (Map.Entry<String, Object> entry : formFields.entrySet()) {
+             System.out.println(entry.getKey() + ": " + entry.getValue());
+     }
 
         return formFields;
         }


### PR DESCRIPTION
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
The HTML form date boxes can only detect dates of the type yyyy-mm-dd while the Securian form follows type mm/dd/yyyy. The changes in the code rearrange the mm/dd/yyyy that the OCR extracts to yyyy-mm-dd.

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->
- [X] New feature (non-breaking change which adds functionality)

## Notes for Reviewer

<!-- Please describe how the reviewer can test your code and/or run the feature you have implemented. -->
- When you upload a form from the frontend, you'll be able to see the new date format take place.
## Questions and Comments (if applicable)

## Checklist

- [X] I have performed a self-review of my own code.
